### PR TITLE
refactor: centralise scenario and year configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,11 @@
+"""Shared configuration for modelling scenarios and years."""
+from __future__ import annotations
+
+from typing import List
+
+# Default scenario names evaluated by the modelling pipelines
+SCENARIOS: List[str] = ["bau", "clean_push", "biogas_incentive"]
+
+# Default years evaluated by the modelling pipelines
+YEARS: List[int] = [2030, 2040, 2050]
+

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ import os
 
 import modelling_stock_flow as msf
 import modelling_cost as mc
+from config import SCENARIOS, YEARS
 
 
 def main() -> None:
@@ -34,15 +35,28 @@ def main() -> None:
         choices=["stockflow", "cost"],
         help="Select which modelling pipeline to run: 'stockflow' or 'cost'.",
     )
+    parser.add_argument(
+        "--scenarios",
+        nargs="+",
+        default=SCENARIOS,
+        help="Scenarios to evaluate. Defaults to all configured scenarios.",
+    )
+    parser.add_argument(
+        "--years",
+        nargs="+",
+        type=int,
+        default=YEARS,
+        help="Model years to evaluate. Defaults to all configured years.",
+    )
     args = parser.parse_args()
     os.makedirs("results", exist_ok=True)
     if args.pipeline == "stockflow":
-        msf.run_all_scenarios()
+        msf.run_all_scenarios(args.scenarios, args.years)
         print(
             "✔ Stock‑flow scenarios have been generated and saved to the results directory."
         )
     elif args.pipeline == "cost":
-        mc.run_all_scenarios()
+        mc.run_all_scenarios(args.scenarios, args.years)
         print(
             "✔ Cost analysis scenarios have been generated and saved to the results directory."
         )

--- a/modelling_cost.py
+++ b/modelling_cost.py
@@ -35,10 +35,7 @@ from spatial_config import (
 )
 from technology_adoption_model import get_tech_mix_by_scenario
 from model import run_cost_fixed_mix
-
-# Scenarios and years to evaluate
-SCENARIOS: List[str] = ["bau", "clean_push", "biogas_incentive"]
-YEARS: List[int] = [2030, 2040, 2050]
+from config import SCENARIOS, YEARS
 DISCOUNT_RATE = 0.05
 BASE_YEAR = 2025
 
@@ -94,8 +91,17 @@ def _compute_levelised_costs() -> Dict[str, float]:
     return levelised
 
 
-def run_all_scenarios() -> Tuple[pd.DataFrame, pd.DataFrame]:
+def run_all_scenarios(
+    scenarios: List[str] | None = None, years: List[int] | None = None
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Execute the cost optimisation pipeline across all scenarios and years.
+
+    Parameters
+    ----------
+    scenarios : list, optional
+        Scenario names to evaluate. Defaults to :data:`config.SCENARIOS`.
+    years : list, optional
+        Model years to process. Defaults to :data:`config.YEARS`.
 
     Returns
     -------
@@ -103,13 +109,15 @@ def run_all_scenarios() -> Tuple[pd.DataFrame, pd.DataFrame]:
         A tuple containing the detailed results for each region and the
         summary of total costs by scenario and year.
     """
+    scenarios = scenarios or SCENARIOS
+    years = years or YEARS
     os.makedirs("results", exist_ok=True)
     tech_costs: Dict[str, float] = _compute_levelised_costs()
     all_rows: List[pd.DataFrame] = []
     summary_rows: List[Dict[str, float]] = []
 
-    for scenario in SCENARIOS:
-        for year in YEARS:
+    for scenario in scenarios:
+        for year in years:
             for reg in regions:
                 demand = demand_by_region_year.get(year, {}).get(reg, 0.0)
                 urban_hh = urban_hh_by_region_year.get(year, {}).get(reg, 0.0)


### PR DESCRIPTION
## Summary
- centralise scenario and year constants in new `config.py`
- allow overriding scenarios and years in modelling pipelines
- extend CLI with `--scenarios` and `--years` options to select subsets

## Testing
- `python -m py_compile config.py modelling_cost.py modelling_stock_flow.py main.py`
- `python main.py cost --scenarios bau --years 2030`
- `python main.py stockflow --scenarios bau --years 2030`
