### PR TITLE
Docs: clarify main.py usage and add license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 2kam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ with underscores.
 
 ## Running the models
 
+The `main.py` script acts as a dispatcher and must be provided with a
+`pipeline` argument, either `stockflow` or `cost`. Run it with the
+following format:
+
+```bash
+python main.py <pipeline>
+```
+
+The script automatically creates a `results/` directory where outputs
+are stored.
+
 1. **Clone or download the repository** and navigate to its root
    directory.
 
@@ -102,3 +113,12 @@ incorporates fixes for parameter drift, unified technology lists and
 scenario name normalisation and reads all household projections from a
 single CSV. The readme provides a step‑by‑step guide to running both
 models and verifying the outputs.
+
+## Author
+
+Created by [2kam](https://github.com/2kam).
+
+## License
+
+Released under the MIT License. See [LICENSE](LICENSE) for details.
+

--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
 """
 Entry point for the CI bioenergy modelling suite.
 
+Author: 2kam
+License: MIT
+
 This script acts as a dispatcher between the stock‑flow and cost
 analysis pipelines. Invoke it with a single positional argument
 specifying which pipeline to run. For example::

--- a/modelling_cost.py
+++ b/modelling_cost.py
@@ -1,6 +1,9 @@
 """
 Cost optimisation pipeline for the CI bioenergy project.
 
+Author: 2kam
+License: MIT
+
 This module performs a simplified least‑cost analysis of clean cooking
 technology pathways at the district level. For each scenario and year,
 it allocates regional cooking energy demand across the available

--- a/modelling_stock_flow.py
+++ b/modelling_stock_flow.py
@@ -1,6 +1,9 @@
 """
 Stock-flow modelling pipeline for the CI bioenergy project.
 
+Author: 2kam
+License: MIT
+
 This module orchestrates a high‑level simulation of future clean
 cooking demand and associated greenhouse gas emissions across Côte
 d'Ivoire. It follows the stock‑and‑flow philosophy, projecting


### PR DESCRIPTION
## Summary
- Documented how `main.py` dispatches to the `stockflow` or `cost` pipelines
- Added author attribution (2kam) and MIT licensing in README and code modules
- Introduced `LICENSE` file

## Testing
- `python -m pytest`