### PR TITLE
Remove redundant scenario/year preload loop

### DIFF
--- a/modelling_cost.py
+++ b/modelling_cost.py
@@ -34,37 +34,32 @@ from spatial_config import (
     demand_by_region_year,
     urban_hh_by_region_year,
     rural_hh_by_region_year,
+    URBAN_DEMAND_GJ_PER_HH,
+    RURAL_DEMAND_GJ_PER_HH,
 )
 from technology_adoption_model import get_tech_mix_by_scenario
 from model import run_cost_fixed_mix
 from config import SCENARIOS, YEARS
+
 DISCOUNT_RATE = 0.05
 BASE_YEAR = 2025
 
 
-
-def _load_levelised_costs(scenario: str, year: int) -> Dict[str, float]:
-    """Load or derive levelised costs for a scenario-year pair.
+def _compute_levelised_costs(urban_hh: float, rural_hh: float) -> Dict[str, float]:
+    """Derive an approximate cost per gigajoule for each technology.
 
     Parameters
     ----------
-    scenario : str
-        Scenario name. Currently unused but retained for a stable API.
-    year : int
-        Model year. Currently unused but retained for a stable API.
+    urban_hh : float
+        Number of urban households.
+    rural_hh : float
+        Number of rural households.
 
     Returns
     -------
     dict
         Mapping of technology names to levelised cost per GJ (USD/GJ).
-
-    Notes
-    -----
-    The costs are presently static and do not vary by scenario or year.
-    They mirror the assumptions used in :func:`_compute_levelised_costs`
-    but avoid recomputing the values for every region.
     """
-
     capex = {
         "firewood": 0,
         "charcoal": 0,
@@ -88,97 +83,8 @@ def _load_levelised_costs(scenario: str, year: int) -> Dict[str, float]:
         "improved_biomass": 4,
     }
 
-    years_lifetime = 15
-    annual_energy_per_hh = (
-        URBAN_DEMAND_GJ_PER_HH + RURAL_DEMAND_GJ_PER_HH
-    ) / 2
-
-    levelised: Dict[str, float] = {}
-    for tech in fuel:
-        capex_per_gj = 0.0
-        if capex.get(tech, 0) > 0:
-            capex_per_gj = capex[tech] / (annual_energy_per_hh * years_lifetime)
-        levelised[tech] = fuel[tech] + capex_per_gj
-
-    return levelised
-
-def _compute_levelised_costs(urban_hh: float, rural_hh: float) -> Dict[str, float]:
-    """Derive an approximate cost per gigajoule for each technology.
-
-
-def _load_levelised_costs(
-    scenario: str | None = None, year: int | None = None
-) -> Dict[str, float]:
-  
-    """Load levelised cost data from ``data/tech_specs.csv``.
-
-    The CSV must contain ``Technology`` and ``Cost_per_GJ`` columns. If
-    optional ``Scenario`` or ``Year`` columns are present, this function
-    filters the table using the provided ``scenario`` and ``year``
-    parameters.
-
-
-    Parameters
-    ----------
-    scenario : str, optional
-        Scenario name to filter on when a ``Scenario`` column exists.
-    year : int, optional
-        Year to filter on when a ``Year`` column exists.
-
-def _compute_levelised_costs(urban_hh: float, rural_hh: float) -> Dict[str, float]:
-
-    """Derive an approximate cost per gigajoule for each technology.
-
-
-def _load_levelised_costs() -> Dict[str, float]:
-    """Load levelised costs per gigajoule for each technology.
-
-    Returns
-    -------
-    dict
-        Mapping of technology names to levelised cost per GJ (USD/GJ).
-    """
-
-    df = pd.read_csv(os.path.join("data", "tech_specs.csv"))
-    return dict(zip(df["Technology"], df["Cost_per_GJ"]))
-
-    data_path = os.path.join(os.path.dirname(__file__), "data", "tech_specs.csv")
-    df = pd.read_csv(data_path)
-
-    if scenario is not None and "Scenario" in df.columns:
-        df = df[df["Scenario"] == scenario]
-    if year is not None and "Year" in df.columns:
-        df = df[df["Year"] == year]
-
-    return dict(zip(df["Technology"], df["Cost_per_GJ"]))
-
-    # CAPEX per household (USD) amortised over 15 years
-    capex = {
-        "firewood": 0,
-        "charcoal": 0,
-        "ics_firewood": 25,
-        "ics_charcoal": 30,
-        "biogas": 450,
-        "ethanol": 75,
-        "electricity": 100,
-        "lpg": 60,
-        "improved_biomass": 40,
-    }
-    # Fuel cost per GJ (USD)
-    fuel = {
-        "firewood": 2,
-        "charcoal": 6,
-        "ics_firewood": 2,
-        "ics_charcoal": 6,
-        "biogas": 1,
-        "ethanol": 15,
-        "electricity": 12,
-        "lpg": 10,
-        "improved_biomass": 4,
-    }
     levelised: Dict[str, float] = {}
     years_lifetime = 15
-    # Compute average household demand weighted by urban/rural counts
     total_hh = urban_hh + rural_hh
     if total_hh > 0:
         annual_energy_per_hh = (
@@ -186,15 +92,31 @@ def _load_levelised_costs() -> Dict[str, float]:
             + (RURAL_DEMAND_GJ_PER_HH * rural_hh)
         ) / total_hh
     else:
-        # Fallback to simple mean if household data is unavailable
         annual_energy_per_hh = (URBAN_DEMAND_GJ_PER_HH + RURAL_DEMAND_GJ_PER_HH) / 2
-    for tech in fuel.keys():
+    for tech in fuel:
         capex_per_gj = 0.0
         if capex.get(tech, 0) > 0 and annual_energy_per_hh > 0:
             capex_per_gj = capex[tech] / (annual_energy_per_hh * years_lifetime)
         levelised[tech] = fuel[tech] + capex_per_gj
     return levelised
 
+
+def _load_levelised_costs(
+    scenario: str | None = None, year: int | None = None
+) -> Dict[str, float]:
+    """Load levelised costs per gigajoule for each technology.
+
+    The data are read from ``data/tech_specs.csv``. When ``Scenario`` or
+    ``Year`` columns are present, the table is filtered by the provided
+    ``scenario`` and ``year`` values.
+    """
+    data_path = os.path.join("data", "tech_specs.csv")
+    df = pd.read_csv(data_path)
+    if scenario is not None and "Scenario" in df.columns:
+        df = df[df["Scenario"] == scenario]
+    if year is not None and "Year" in df.columns:
+        df = df[df["Year"] == year]
+    return dict(zip(df["Technology"], df["Cost_per_GJ"]))
 
 
 def run_all_scenarios(
@@ -221,19 +143,9 @@ def run_all_scenarios(
     os.makedirs("results", exist_ok=True)
     all_rows: List[pd.DataFrame] = []
     summary_rows: List[Dict[str, float]] = []
-    tech_costs = _load_levelised_costs()
-
-    for scenario in SCENARIOS:
-        for year in YEARS:
-            tech_costs: Dict[str, float] = _load_levelised_costs(scenario, year)
-            
     for scenario in scenarios:
         for year in years:
-
             tech_costs = _load_levelised_costs(scenario, year)
-
-
-
             for reg in regions:
                 demand = demand_by_region_year.get(year, {}).get(reg, 0.0)
                 urban_hh = urban_hh_by_region_year.get(year, {}).get(reg, 0.0)


### PR DESCRIPTION
## Summary
- simplify `run_all_scenarios` by removing redundant nested loops over `SCENARIOS` and `YEARS`
- rebuild cost-loading helpers and import demand constants to fix broken docstrings and compile errors

## Testing
- `python -m py_compile modelling_cost.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ccc580aec8332b82c6bc14bd6a972