### PR TITLE
Add CSV exports for modelling results

### DIFF
--- a/modelling_cost.py
+++ b/modelling_cost.py
@@ -14,7 +14,9 @@ costs.
 
 The resulting detailed and summary outputs are written to
 ``results/ci_bioenergy_techpathways.xlsx`` with two sheets: ``Details``
-and ``Summary``.
+and ``Summary``. Additionally, scenario‑specific CSV files are produced
+under ``results/techpathways_<scenario>.csv`` and
+``results/techpathways_summary_<scenario>.csv``.
 
 Example usage::
 
@@ -163,6 +165,9 @@ def run_all_scenarios(
 
     """Execute the cost optimisation pipeline across all scenarios and years.
 
+    The function writes results to an Excel workbook and scenario-specific
+    CSV files for easier analysis.
+
     Parameters
     ----------
     scenarios : list, optional
@@ -225,10 +230,21 @@ def run_all_scenarios(
     # Combine results into DataFrames
     df_full = pd.concat(all_rows, ignore_index=True) if all_rows else pd.DataFrame()
     df_summary = pd.DataFrame(summary_rows)
-    # Write outputs to Excel
+    # Write outputs to Excel and per-scenario CSVs
     output_path = "results/ci_bioenergy_techpathways.xlsx"
     with pd.ExcelWriter(output_path) as writer:
         if not df_full.empty:
             df_full.to_excel(writer, sheet_name="Details", index=False)
         df_summary.to_excel(writer, sheet_name="Summary", index=False)
+
+    if not df_full.empty:
+        for scenario in scenarios:
+            df_full[df_full["Scenario"] == scenario].to_csv(
+                os.path.join("results", f"techpathways_{scenario}.csv"),
+                index=False,
+            )
+            df_summary[df_summary["Scenario"] == scenario].to_csv(
+                os.path.join("results", f"techpathways_summary_{scenario}.csv"),
+                index=False,
+            )
     return df_full, df_summary

--- a/modelling_stock_flow.py
+++ b/modelling_stock_flow.py
@@ -19,7 +19,9 @@ Scenarios are defined in ``SCENARIOS`` and currently include:
 * ``biogas_incentive`` – strong incentives for biogas systems
 
 The results are written to an Excel workbook at
-``results/ci_bioenergy_scenarios.xlsx`` with a sheet per scenario.
+``results/ci_bioenergy_scenarios.xlsx`` with a sheet per scenario and
+to individual CSV files under ``results/stockflow_<scenario>.csv`` for
+easy downstream use.
 
 Example usage::
 
@@ -90,7 +92,7 @@ def _map_energy_categories(energy_by_tech: Dict[str, float]) -> Dict[str, float]
 def run_all_scenarios(
     scenarios: List[str] | None = None, years: List[int] | None = None
 ) -> Dict[str, pd.DataFrame]:
-    """Execute all stock‑flow scenarios and write results to Excel.
+    """Execute all stock‑flow scenarios and write results to Excel and CSV.
 
     Parameters
     ----------
@@ -167,9 +169,11 @@ def run_all_scenarios(
         # Convert to DataFrame
         results_per_scenario[scenario] = pd.DataFrame(scenario_results)
 
-    # Write results to Excel workbook
+    # Write results to Excel workbook and per-scenario CSVs
     output_path = "results/ci_bioenergy_scenarios.xlsx"
     with pd.ExcelWriter(output_path) as writer:
         for scenario, df in results_per_scenario.items():
             df.to_excel(writer, sheet_name=scenario, index=False)
+            csv_path = os.path.join("results", f"stockflow_{scenario}.csv")
+            df.to_csv(csv_path, index=False)
     return results_per_scenario


### PR DESCRIPTION
## Summary
- Save stock-flow outputs to per-scenario CSV files alongside Excel workbook
- Export cost analysis details and summaries to scenario-specific CSV files for each technology pathway

## Testing
- `python -m py_compile modelling_stock_flow.py modelling_cost.py`
- `python main.py stockflow --scenarios bau --years 2025`
- `python main.py cost --scenarios bau --years 2025`


------
https://chatgpt.com/codex/tasks/task_e_689e2d32594483328ab774f040cb7666