### PR TITLE
Add supply-demand comparison tool with target-year scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ python results/aggregate_techpathways.py
 This generates `techpathways_all.csv` and
 `techpathways_summary_all.csv` in the same folder.
 
+## Supply and demand comparison
+
+Estimate the cooking energy demand for future targets and compare it
+with available biomass supply using:
+
+```bash
+python analysis/compare_supply_demand.py --target-year 2030
+```
+
+The script scales 2023 district‑level demand by predefined multipliers
+(`TARGET_MULTIPLIERS`) for 2030, 2040 and 2050, joins the values with
+`regional_supply_full_corrected.csv` and reports the surplus or deficit
+per district. Results are written to `results/supply_demand_<year>.csv`.
+
 ## Reproducibility notes
 
 * Both pipelines read the same demographic data file stored in the

--- a/analysis/compare_supply_demand.py
+++ b/analysis/compare_supply_demand.py
@@ -1,0 +1,66 @@
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Ensure project root is on the Python path when running as a script
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from spatial_config import compute_demand_by_region_year
+
+TARGET_MULTIPLIERS = {2030: 0.58, 2040: 0.20, 2050: 0.05}
+BASE_DEMAND_YEAR = 2023
+
+
+def load_supply():
+    """Load available biomass supply per district in GJ."""
+    supply_df = pd.read_csv("data/regional_supply_full_corrected.csv")
+    supply = supply_df.groupby("District")["Available_GJ"].sum()
+    supply.name = "supply_gj"
+    return supply
+
+
+def compute_scaled_demand(target_year: int) -> pd.Series:
+    """Return scaled demand for ``target_year`` based on 2023 demand."""
+    demand_by_year = compute_demand_by_region_year()
+    base_year = BASE_DEMAND_YEAR
+    if base_year not in demand_by_year:
+        base_year = min(demand_by_year)
+    base_demand = pd.Series(demand_by_year[base_year], name=f"demand_{base_year}")
+    multiplier = TARGET_MULTIPLIERS.get(target_year)
+    if multiplier is None:
+        raise ValueError(f"Unsupported target year: {target_year}")
+    scaled = base_demand * multiplier
+    scaled.name = f"demand_{target_year}"
+    return scaled
+
+
+def compare_supply_demand(target_year: int) -> pd.DataFrame:
+    supply = load_supply()
+    demand = compute_scaled_demand(target_year)
+    df = pd.concat([supply, demand], axis=1)
+    df["surplus_deficit_gj"] = df["supply_gj"] - df[demand.name]
+    return df
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare biomass supply with scaled demand for a target year.")
+    parser.add_argument("--target-year", type=int, choices=TARGET_MULTIPLIERS.keys(), default=2030,
+                        help="Year for demand scaling (default: 2030)")
+    args = parser.parse_args()
+
+    df = compare_supply_demand(args.target_year)
+    out_dir = "results"
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, f"supply_demand_{args.target_year}.csv")
+    df.to_csv(out_path)
+    print(df.sort_values("surplus_deficit_gj", ascending=False).to_string())
+    print(f"\nResults written to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `analysis/compare_supply_demand.py` to scale 2023 demand by target-year multipliers and compare to regional biomass supply.
- Document usage of the new comparison script in the README.

## Testing
- `python analysis/compare_supply_demand.py --target-year 2030`
- `python -m py_compile analysis/compare_supply_demand.py`


------
https://chatgpt.com/codex/tasks/task_e_689e3b8b29588332a0dd2b08be5cc520