### PR TITLE
Add PyPSA export utilities and CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ outside the repository (e.g. in a release asset or shared drive).
    technology and a `Summary` sheet with total costs by scenario and
    year.
 
+   Append ``--pypsa-export`` to additionally produce CSV files
+   compatible with `PyPSA‑Earth <https://pypsa-earth.readthedocs.io/>`_:
+
+   ```bash
+   python main.py cost --pypsa-export
+   ```
+
+   For each scenario and year, the command writes
+   ``results/pypsa/<scenario>/<year>/load.csv`` and
+   ``generators.csv``. ``load.csv`` contains regional
+   cooking‑electricity demand while ``generators.csv`` provides
+   dispatchable biomass, biogas and LPG supply.
+
 5. **Inspect the outputs** using your preferred spreadsheet
    application. For example, the stock–flow model can be checked to
    verify that total demand for 2030 is nearly identical across
@@ -103,6 +116,21 @@ python results/aggregate_techpathways.py
 
 This generates `techpathways_all.csv` and
 `techpathways_summary_all.csv` in the same folder.
+
+## Exporting to PyPSA‑Earth
+
+The CSVs generated with ``--pypsa-export`` can be referenced from a
+PyPSA‑Earth configuration to include clean‑cooking demand and fuel
+supplies. Example snippet:
+
+```yaml
+custom_data:
+  load: results/pypsa/bau/2030/load.csv
+  generators: results/pypsa/bau/2030/generators.csv
+```
+
+Adjust the paths, scenario (``bau``) and year (``2030``) as needed for
+your analysis.
 
 ## Supply and demand comparison
 

--- a/main.py
+++ b/main.py
@@ -51,6 +51,11 @@ def main() -> None:
         default=YEARS,
         help="Model years to evaluate. Defaults to all configured years.",
     )
+    parser.add_argument(
+        "--pypsa-export",
+        action="store_true",
+        help="Write PyPSA-Earth compatible CSVs after running the pipeline.",
+    )
     args = parser.parse_args()
     os.makedirs("results", exist_ok=True)
     if args.pipeline == "stockflow":
@@ -58,11 +63,24 @@ def main() -> None:
         print(
             "✔ Stock‑flow scenarios have been generated and saved to the results directory."
         )
+        if args.pypsa_export:
+            print("⚠ PyPSA export is currently only supported for the cost pipeline.")
     elif args.pipeline == "cost":
-        mc.run_all_scenarios(args.scenarios, args.years)
+        df_full, _ = mc.run_all_scenarios(args.scenarios, args.years)
         print(
             "✔ Cost analysis scenarios have been generated and saved to the results directory."
         )
+        if args.pypsa_export and not df_full.empty:
+            from pypsa_export import write_pypsa_generators, write_pypsa_loads
+
+            for (scenario, year), df_subset in df_full.groupby(["Scenario", "Year"]):
+                tech_costs = mc._load_levelised_costs(scenario, year)
+                out_dir = os.path.join("results", "pypsa", scenario, str(year))
+                write_pypsa_loads(df_subset, out_dir)
+                write_pypsa_generators(df_subset, tech_costs, out_dir)
+            print(
+                "✔ PyPSA export files written under results/pypsa/<scenario>/<year>/"
+            )
 
 
 if __name__ == "__main__":

--- a/pypsa_export.py
+++ b/pypsa_export.py
@@ -1,0 +1,142 @@
+"""Utilities for exporting results to the PyPSA-Earth format.
+
+This module provides helpers to translate the modelling outputs
+into the CSV structures expected by `PyPSA-Earth`_. It focuses on
+providing regional cooking-electricity demand as loads and the
+availability of clean cooking fuels as dispatchable generators.
+
+The export functions intentionally cover only the subset of
+technologies that map cleanly to power-system components:
+
+* ``electricity`` demand is mapped to :file:`load.csv` entries.
+* ``biomass`` (aggregated from traditional and improved biomass
+  technologies), ``biogas`` and ``lpg`` supplies are mapped to
+  :file:`generators.csv` entries.
+
+The resulting CSV files can be referenced from a PyPSA-Earth
+``config.yaml`` to integrate cooking energy considerations into
+broader power-system analyses.
+
+.. _PyPSA-Earth: https://pypsa-earth.readthedocs.io/
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import pandas as pd
+
+
+_HOURS_PER_YEAR = 8760
+_GJ_TO_MWH = 1 / 3.6  # 1 GJ = 0.277777... MWh
+
+
+def _ensure_dir(path: str) -> None:
+    """Create ``path`` if it does not yet exist."""
+
+    os.makedirs(path, exist_ok=True)
+
+
+def write_pypsa_loads(df_results: pd.DataFrame, output_dir: str) -> None:
+    """Export regional electricity demand in ``load.csv`` format.
+
+    Parameters
+    ----------
+    df_results:
+        DataFrame with at least the columns ``Region``, ``Technology`` and
+        ``Energy_GJ``. Only rows where ``Technology`` equals ``"electricity"``
+        are considered.
+    output_dir:
+        Directory where :file:`load.csv` will be written.
+
+    Notes
+    -----
+    ``p_set`` is computed as the average power in megawatts using
+    ``Energy_GJ / (3.6 * 8760)``.
+    """
+
+    loads = df_results[df_results["Technology"] == "electricity"]
+    if loads.empty:
+        return
+
+    loads = loads.groupby("Region")["Energy_GJ"].sum().reset_index()
+    loads["name"] = loads["Region"].apply(lambda r: f"load_{r}")
+    loads["bus"] = loads["Region"]
+    loads["p_set"] = loads["Energy_GJ"] * _GJ_TO_MWH / _HOURS_PER_YEAR
+
+    _ensure_dir(output_dir)
+    loads[["name", "bus", "p_set"]].to_csv(os.path.join(output_dir, "load.csv"), index=False)
+
+
+def write_pypsa_generators(
+    df_results: pd.DataFrame, tech_costs: Dict[str, float], output_dir: str
+) -> None:
+    """Export fuel supplies as dispatchable generators.
+
+    Parameters
+    ----------
+    df_results:
+        DataFrame with columns ``Region``, ``Technology`` and ``Energy_GJ``.
+    tech_costs:
+        Mapping of technology names to levelised cost in ``USD/GJ``. Costs
+        are converted to ``USD/MWh`` when populating ``marginal_cost``.
+    output_dir:
+        Directory where :file:`generators.csv` will be written.
+
+    Notes
+    -----
+    The function aggregates individual technology rows into three carriers:
+    ``biomass`` (firewood, charcoal, ICS variants and improved biomass),
+    ``biogas`` and ``lpg``. For each region a single generator is created per
+    carrier with ``p_nom`` corresponding to the average available power and
+    ``p_max_pu`` fixed at ``1`` (fully dispatchable).
+    """
+
+    carrier_map = {
+        "biomass": [
+            "firewood",
+            "charcoal",
+            "ics_firewood",
+            "ics_charcoal",
+            "improved_biomass",
+        ],
+        "biogas": ["biogas"],
+        "lpg": ["lpg"],
+    }
+
+    rows = []
+    for carrier, techs in carrier_map.items():
+        subset = df_results[df_results["Technology"].isin(techs)]
+        if subset.empty:
+            continue
+        grouped = subset.groupby(["Region", "Technology"]) ["Energy_GJ"].sum().reset_index()
+        for region in grouped["Region"].unique():
+            reg_df = grouped[grouped["Region"] == region]
+            total_energy = reg_df["Energy_GJ"].sum()
+            if total_energy <= 0:
+                continue
+            p_nom = total_energy * _GJ_TO_MWH / _HOURS_PER_YEAR
+            # Weighted average cost across contributing technologies
+            weighted_cost_gj = sum(
+                row["Energy_GJ"] * tech_costs.get(row["Technology"], 0.0)
+                for _, row in reg_df.iterrows()
+            ) / total_energy
+            marginal_cost = weighted_cost_gj / _GJ_TO_MWH  # USD/MWh
+            rows.append(
+                {
+                    "name": f"{carrier}_{region}",
+                    "bus": region,
+                    "carrier": carrier,
+                    "p_nom": p_nom,
+                    "p_max_pu": 1.0,
+                    "marginal_cost": marginal_cost,
+                }
+            )
+
+    if rows:
+        _ensure_dir(output_dir)
+        cols = ["name", "bus", "carrier", "p_nom", "p_max_pu", "marginal_cost"]
+        pd.DataFrame(rows)[cols].to_csv(
+            os.path.join(output_dir, "generators.csv"), index=False
+        )


### PR DESCRIPTION
## Summary
- add `pypsa_export` module to create PyPSA-Earth `load.csv` and `generators.csv`
- expose `--pypsa-export` flag in `main.py` to generate files after cost runs
- document PyPSA export usage and config snippet in README

## Testing
- `python -m py_compile main.py pypsa_export.py`
