### PR TITLE
Handle zero-sum ERA5 profiles in hourly disaggregation

### DIFF
--- a/energy_demand_model.py
+++ b/energy_demand_model.py
@@ -78,7 +78,8 @@ def disaggregate_to_hourly(annual_gj: float, cutout_path: str, variable: str, re
     """Disaggregate annual energy demand to an hourly series using ERA5 data.
 
     The ERA5 profile is averaged over the provided region and normalised to
-    unit sum before weighting the annual total.
+    unit sum before weighting the annual total. If the profile sums to zero,
+    a :class:`ValueError` is raised.
 
     Parameters
     ----------
@@ -98,7 +99,12 @@ def disaggregate_to_hourly(annual_gj: float, cutout_path: str, variable: str, re
         Hourly energy demand in gigajoules.
     """
     profile = load_era5_series(cutout_path, variable, region_geom)
-    weights = profile / profile.sum()
+    total = profile.sum()
+    if total == 0:
+        raise ValueError(
+            "ERA5 profile sums to zero; cannot disaggregate to hourly series"
+        )
+    weights = profile / total
     return weights * annual_gj
 # -------------------------------------------------------
 # Parameters and Precomputed Demand Table

--- a/tests/test_energy_demand_model.py
+++ b/tests/test_energy_demand_model.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import pytest
+import sys
+import types
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Provide stub modules required by energy_demand_model on import
+spatial_config = types.ModuleType("spatial_config")
+spatial_config.regions = []
+spatial_config.URBAN_DEMAND_GJ_PER_HH = 0
+spatial_config.RURAL_DEMAND_GJ_PER_HH = 0
+sys.modules["spatial_config"] = spatial_config
+
+data_input = types.ModuleType("data_input")
+data_input.get_parameters = lambda: {
+    "population_total_2025": 0,
+    "population_growth_rate_annual": 0,
+    "cooking_energy_demand_per_capita_GJ_yr": 0,
+}
+sys.modules["data_input"] = data_input
+
+era5_profiles = types.ModuleType("era5_profiles")
+era5_profiles.load_era5_series = lambda *args, **kwargs: None
+sys.modules["era5_profiles"] = era5_profiles
+
+import energy_demand_model as edm
+
+
+def test_disaggregate_to_hourly_zero_profile(monkeypatch):
+    series = pd.Series([0, 0, 0], index=pd.date_range("2020-01-01", periods=3, freq="h"))
+    monkeypatch.setattr(edm, "load_era5_series", lambda *args, **kwargs: series)
+    with pytest.raises(ValueError, match="profile sums to zero"):
+        edm.disaggregate_to_hourly(10, "dummy", "t2m", None)
+
+
+def test_disaggregate_to_hourly_nonzero_profile(monkeypatch):
+    series = pd.Series([1, 2, 3], index=pd.date_range("2020-01-01", periods=3, freq="h"))
+    monkeypatch.setattr(edm, "load_era5_series", lambda *args, **kwargs: series)
+    result = edm.disaggregate_to_hourly(6, "dummy", "t2m", None)
+    expected = pd.Series([1.0, 2.0, 3.0], index=series.index)
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- guard against zero-sum ERA5 profiles when disaggregating annual demand and raise a clear error
- test hourly disaggregation for zero and non-zero ERA5 profiles

## Testing
- `pytest -q`
