### PR TITLE
Validate household columns and guard bus CSV generation

### DIFF
--- a/spatial_config.py
+++ b/spatial_config.py
@@ -17,7 +17,15 @@ regions = sorted(demographics.index.get_level_values("District").unique())
 URBAN_DEMAND_GJ_PER_HH = 6.5  # IEA (2024), page 5
 RURAL_DEMAND_GJ_PER_HH = 5.5  # IEA (2024), page 5
 
+
 def compute_demand_by_region_year():
+    required_cols = {"Urban_Households", "Rural_Households"}
+    missing = required_cols - set(demographics.columns)
+    if missing:
+        raise KeyError(
+            f"Missing required columns: {', '.join(sorted(missing))}"
+        )
+
     demand = {}
     for (district, year), row in demographics.iterrows():
         if year not in demand:
@@ -81,6 +89,6 @@ def generate_buses_csv(output_path: str = os.path.join("results", "buses.csv")) 
     return buses_df
 
 
-# Generate buses.csv on import so downstream modules can rely on it
-buses_df = generate_buses_csv()
+if __name__ == "__main__":
+    buses_df = generate_buses_csv()
 

--- a/tests/test_spatial_config.py
+++ b/tests/test_spatial_config.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import importlib
+
+
+@pytest.fixture
+def spatial_config_module(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "District": ["A"],
+            "Year": [2020],
+            "Urban_Households": [1],
+            "Rural_Households": [2],
+        }
+    )
+    monkeypatch.setattr(pd, "read_csv", lambda *args, **kwargs: df.copy())
+    if "spatial_config" in sys.modules:
+        del sys.modules["spatial_config"]
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+    module = importlib.import_module("spatial_config")
+    return module
+
+
+@pytest.mark.parametrize("missing_col", ["Urban_Households", "Rural_Households"])
+def test_compute_demand_by_region_year_missing_columns(spatial_config_module, monkeypatch, missing_col):
+    df = pd.DataFrame(
+        {
+            "District": ["A"],
+            "Year": [2020],
+            "Urban_Households": [1],
+            "Rural_Households": [2],
+        }
+    ).drop(columns=[missing_col])
+    df.set_index(["District", "Year"], inplace=True)
+    monkeypatch.setattr(spatial_config_module, "demographics", df)
+    with pytest.raises(KeyError, match=missing_col):
+        spatial_config_module.compute_demand_by_region_year()
+
+
+def test_generate_buses_csv_only_when_run_as_script(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    csv_path = data_dir / "District-level_Household_Projections.csv"
+    df = pd.DataFrame(
+        {
+            "District": ["A"],
+            "Year": [2020],
+            "Urban_Households": [1],
+            "Rural_Households": [1],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+
+    results_file = tmp_path / "results" / "buses.csv"
+
+    subprocess.run(
+        [sys.executable, "-c", "import spatial_config"],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+    assert not results_file.exists()
+
+    subprocess.run(
+        [sys.executable, "-m", "spatial_config"],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+    )
+    assert results_file.exists()


### PR DESCRIPTION
## Summary
- Ensure `compute_demand_by_region_year` checks for required `Urban_Households` and `Rural_Households` columns
- Move `generate_buses_csv()` invocation under `if __name__ == "__main__"` to prevent side effects on import
- Add tests covering missing-column errors and script-only bus CSV generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ef4e2ab788332867bb33b78de701a