### PR TITLE
Add frequency option for ERA5 profile disaggregation

### DIFF
--- a/tests/test_energy_demand_model.py
+++ b/tests/test_energy_demand_model.py
@@ -42,3 +42,16 @@ def test_disaggregate_to_hourly_nonzero_profile(monkeypatch):
     expected = pd.Series([1.0, 2.0, 3.0], index=series.index)
     pd.testing.assert_series_equal(result, expected)
 
+
+def test_disaggregate_to_hourly_resample(monkeypatch):
+    series = pd.Series(
+        [1, 1, 1, 1], index=pd.date_range("2020-01-01", periods=4, freq="h")
+    )
+    edm = _import_edm(monkeypatch, series)
+
+    result = edm.disaggregate_to_hourly(8, "dummy", "t2m", None, freq="4H")
+    expected = pd.Series(
+        [8.0], index=pd.date_range("2020-01-01", periods=1, freq="4H")
+    )
+    pd.testing.assert_series_equal(result, expected)
+


### PR DESCRIPTION
## Summary
- allow disaggregate_to_hourly to accept a `freq` parameter for custom time steps
- resample ERA5 profiles when `freq` differs from hourly
- document `freq` (including `"4H"` support) and test resampling behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f1e2e6a308332906d1d5e98651733