### PR TITLE
Add selectable solver for cost optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ with underscores.
 * The only required Python package is **pandas**. The cost pipeline can
   optionally solve a least‑cost optimisation using **PuLP**. Install it
   with `pip install pulp` if you intend to run the optimisation mode.
+  CBC ships with PuLP, while ``--solver glpk`` requires the external
+  ``glpsol`` binary and ``--solver gurobi`` needs a licensed Gurobi
+  installation.
 
 ## Preparing ERA5 weather cutouts
 
@@ -90,6 +93,8 @@ outside the repository (e.g. in a release asset or shared drive).
    python main.py cost
    # or solve an optimisation with policy constraints (requires PuLP)
    python main.py cost --optimise
+   # select an alternative solver such as GLPK
+   python main.py cost --optimise --solver glpk
    ```
 
    The results will be saved to `results/ci_bioenergy_techpathways.xlsx`.

--- a/main.py
+++ b/main.py
@@ -67,6 +67,12 @@ def main() -> None:
         default="none",
         help="Select demand output: annual only or 4-hour ERA5-based series.",
     )
+    parser.add_argument(
+        "--solver",
+        choices=["cbc", "glpk", "gurobi"],
+        default="cbc",
+        help="Select optimisation solver when using --optimise.",
+    )
     args = parser.parse_args()
     os.makedirs("results", exist_ok=True)
     if args.pipeline == "stockflow":
@@ -78,7 +84,11 @@ def main() -> None:
             print("⚠ PyPSA export is currently only supported for the cost pipeline.")
     elif args.pipeline == "cost":
         df_full, _ = mc.run_all_scenarios(
-            args.scenarios, args.years, optimise=args.optimise, timeseries=args.timeseries
+            args.scenarios,
+            args.years,
+            optimise=args.optimise,
+            timeseries=args.timeseries,
+            solver=args.solver,
         )
         print(
             "✔ Cost analysis scenarios have been generated and saved to the results directory."

--- a/modelling_cost.py
+++ b/modelling_cost.py
@@ -181,6 +181,7 @@ def run_all_scenarios(
     years: List[int] | None = None,
     optimise: bool = False,
     timeseries: str = "none",
+    solver: str = "cbc",
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
 
     """Execute the cost optimisation pipeline across all scenarios and years.
@@ -197,6 +198,9 @@ def run_all_scenarios(
     optimise : bool, optional
         If ``True``, solve a least-cost optimisation using PuLP.
         Otherwise use the fixed adoption shares.
+    solver : str, optional
+        Optimisation solver to use when ``optimise`` is ``True``.
+        Choices are ``"cbc"``, ``"glpk"`` and ``"gurobi"``.
 
     Returns
     -------
@@ -256,6 +260,7 @@ def run_all_scenarios(
                         MIN_CLEAN_SHARE,
                         MAX_FIREWOOD_SHARE,
                         tech_costs,
+                        solver=solver,
                     )
                 else:
                     # Derive energy shares for the district using the adoption model

--- a/tests/test_solver_selection.py
+++ b/tests/test_solver_selection.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import model
+
+pulp = model.pulp
+
+@pytest.mark.skipif(pulp is None, reason="PuLP not installed")
+def test_run_cost_minimise_cost_cbc():
+    tech_costs = {
+        "firewood": 2,
+        "charcoal": 3,
+        "biogas": 1,
+        "ethanol": 4,
+        "electricity": 5,
+        "lpg": 6,
+        "improved_biomass": 2,
+    }
+    df, cost = model.run_cost_minimise_cost(
+        2025, "reg", 10, 0, 1, tech_costs, solver="cbc"
+    )
+    assert pytest.approx(df["Energy_GJ"].sum()) == 10
+    assert cost >= 0
+
+@pytest.mark.skipif(pulp is None, reason="PuLP not installed")
+def test_run_cost_minimise_cost_glpk():
+    tech_costs = {
+        "firewood": 2,
+        "charcoal": 3,
+        "biogas": 1,
+        "ethanol": 4,
+        "electricity": 5,
+        "lpg": 6,
+        "improved_biomass": 2,
+    }
+    if pulp.GLPK_CMD().available():
+        df, _ = model.run_cost_minimise_cost(
+            2025, "reg", 10, 0, 1, tech_costs, solver="glpk"
+        )
+        assert pytest.approx(df["Energy_GJ"].sum()) == 10
+    else:
+        with pytest.raises(RuntimeError):
+            model.run_cost_minimise_cost(
+                2025, "reg", 10, 0, 1, tech_costs, solver="glpk"
+            )


### PR DESCRIPTION
## Summary
- add `--solver` flag to choose optimisation backend
- plumb solver option through cost pipeline
- dispatch to CBC, GLPK or Gurobi in `run_cost_minimise_cost`
- document solver usage and dependencies
- include tests for solver selection

## Testing
- `pip install pulp`
- `pip install pandas`
- `pytest tests/test_solver_selection.py -q`
