### PR TITLE
Refactor demand handling into dedicated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ harmonised list of technologies (`firewood`, `charcoal`,
 `lpg`, `improved_biomass`). Scenario names are normalised to lowercase
 with underscores.
 
+## Data flow
+
+```mermaid
+flowchart LR
+    A[data/District-level_Household_Projections.csv]
+    B[demand.demographics\n(load_demographics, compute_*)]
+    C[results/buses.csv]
+    D[energy_demand_model]
+    E[modelling_cost]
+    F[analysis scripts]
+    G[pypsa_export]
+
+    A --> B
+    B --> C
+    B --> D
+    B --> E
+    B --> F
+    C --> G
+```
+
+The :mod:`demand` package loads demographic projections, derives
+regional household demand and writes optional bus metadata.  The demand
+figures feed into the energy demand and cost models as well as auxiliary
+analysis scripts.  The generated ``buses.csv`` is consumed by the
+PyPSA‑Earth export utilities.
+
 ## Prerequisites
 
 * Python 3.8 or later.

--- a/analysis/compare_supply_demand.py
+++ b/analysis/compare_supply_demand.py
@@ -10,7 +10,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from spatial_config import compute_demand_by_region_year
+from demand import get_demand
+from demand.demographics import demand_by_region_year
 from paths import get_data_path
 
 TARGET_MULTIPLIERS = {2030: 0.58, 2040: 0.20, 2050: 0.05}
@@ -29,11 +30,12 @@ def load_supply():
 
 def compute_scaled_demand(target_year: int) -> pd.Series:
     """Return scaled demand for ``target_year`` based on 2023 demand."""
-    demand_by_year = compute_demand_by_region_year()
     base_year = BASE_DEMAND_YEAR
-    if base_year not in demand_by_year:
-        base_year = min(demand_by_year)
-    base_demand = pd.Series(demand_by_year[base_year], name=f"demand_{base_year}")
+    demand = get_demand(base_year)
+    if not demand:
+        base_year = min(demand_by_region_year)
+        demand = get_demand(base_year)
+    base_demand = pd.Series(demand, name=f"demand_{base_year}")
     multiplier = TARGET_MULTIPLIERS.get(target_year)
     if multiplier is None:
         raise ValueError(f"Unsupported target year: {target_year}")

--- a/demand/__init__.py
+++ b/demand/__init__.py
@@ -1,0 +1,49 @@
+"""Demand package exposing demographic-based demand utilities."""
+
+from __future__ import annotations
+
+from .demographics import (
+    URBAN_DEMAND_GJ_PER_HH,
+    RURAL_DEMAND_GJ_PER_HH,
+    load_demographics,
+    demographics,
+    regions,
+    compute_demand_by_region_year,
+    compute_urban_rural_hh_by_region_year,
+    demand_by_region_year,
+    urban_hh_by_region_year,
+    rural_hh_by_region_year,
+)
+
+
+def get_demand(year: int) -> dict[str, float]:
+    """Return regional demand (GJ) for ``year``.
+
+    Parameters
+    ----------
+    year : int
+        Target year.
+
+    Returns
+    -------
+    dict
+        Mapping of region names to cooking energy demand in gigajoules.
+    """
+
+    return demand_by_region_year.get(year, {})
+
+
+__all__ = [
+    "URBAN_DEMAND_GJ_PER_HH",
+    "RURAL_DEMAND_GJ_PER_HH",
+    "load_demographics",
+    "demographics",
+    "regions",
+    "compute_demand_by_region_year",
+    "compute_urban_rural_hh_by_region_year",
+    "demand_by_region_year",
+    "urban_hh_by_region_year",
+    "rural_hh_by_region_year",
+    "get_demand",
+]
+

--- a/demand/demographics.py
+++ b/demand/demographics.py
@@ -1,0 +1,122 @@
+"""Demographic data loading and cooking demand calculations.
+
+This module centralises access to household projections and derived
+regional demand figures.  It was previously part of
+``spatial_config.py`` but now lives in the :mod:`demand` package to
+provide a clearer API for other components.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+import pandas as pd
+
+from paths import get_data_path
+
+
+# Assumed cooking energy demand per household in GJ/year (source: IEA
+# country brief for Côte d'Ivoire, 2024)
+URBAN_DEMAND_GJ_PER_HH = 6.5  # IEA (2024), page 5
+RURAL_DEMAND_GJ_PER_HH = 5.5  # IEA (2024), page 5
+
+
+@lru_cache()
+def load_demographics() -> pd.DataFrame:
+    """Load district-level household projections.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame indexed by ``District`` and ``Year`` with columns for
+        ``Urban_Households`` and ``Rural_Households``.
+    """
+
+    path = get_data_path("District-level_Household_Projections.csv")
+    try:
+        df = pd.read_csv(path)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Demographic projection file not found: {path}"
+        ) from exc
+    df.columns = df.columns.str.strip()
+    df.set_index(["District", "Year"], inplace=True)
+    return df
+
+
+# Load once for module-level calculations but keep loader for reuse
+demographics = load_demographics()
+
+
+# Extract regions (districts)
+regions = sorted(demographics.index.get_level_values("District").unique())
+
+
+def compute_demand_by_region_year(df: pd.DataFrame | None = None):
+    """Return total household cooking demand for each region and year.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame, optional
+        Alternative demographic data frame.  Must contain the columns
+        ``Urban_Households`` and ``Rural_Households`` and be indexed by
+        ``District`` and ``Year``.  If omitted, the preloaded
+        :data:`demographics` table is used.
+
+    Returns
+    -------
+    dict
+        Nested mapping ``{year: {district: demand_GJ}}``.
+    """
+
+    df = df if df is not None else demographics
+    required_cols = {"Urban_Households", "Rural_Households"}
+    missing = required_cols - set(df.columns)
+    if missing:
+        raise KeyError(
+            f"Missing required columns: {', '.join(sorted(missing))}"
+        )
+
+    demand: dict[int, dict[str, float]] = {}
+    for (district, year), row in df.iterrows():
+        if year not in demand:
+            demand[year] = {}
+        urban_demand = row["Urban_Households"] * URBAN_DEMAND_GJ_PER_HH
+        rural_demand = row["Rural_Households"] * RURAL_DEMAND_GJ_PER_HH
+        total_demand = urban_demand + rural_demand
+        demand[year][district] = total_demand
+    return demand
+
+
+def compute_urban_rural_hh_by_region_year(df: pd.DataFrame | None = None):
+    """Return household counts split by urban/rural for each region/year."""
+
+    df = df if df is not None else demographics
+    urban: dict[int, dict[str, float]] = {}
+    rural: dict[int, dict[str, float]] = {}
+    for (district, year), row in df.iterrows():
+        if year not in urban:
+            urban[year] = {}
+            rural[year] = {}
+        urban[year][district] = row["Urban_Households"]
+        rural[year][district] = row["Rural_Households"]
+    return urban, rural
+
+
+# Precompute values for use in optimisation and adoption models
+demand_by_region_year = compute_demand_by_region_year()
+urban_hh_by_region_year, rural_hh_by_region_year = compute_urban_rural_hh_by_region_year()
+
+
+__all__ = [
+    "URBAN_DEMAND_GJ_PER_HH",
+    "RURAL_DEMAND_GJ_PER_HH",
+    "load_demographics",
+    "demographics",
+    "regions",
+    "compute_demand_by_region_year",
+    "compute_urban_rural_hh_by_region_year",
+    "demand_by_region_year",
+    "urban_hh_by_region_year",
+    "rural_hh_by_region_year",
+]
+

--- a/energy_demand_model.py
+++ b/energy_demand_model.py
@@ -8,7 +8,7 @@ from numbers import Real
 import pandas as pd
 
 try:
-    from spatial_config import (
+    from demand import (
         regions,
         URBAN_DEMAND_GJ_PER_HH,
         RURAL_DEMAND_GJ_PER_HH,
@@ -23,7 +23,7 @@ except Exception:  # pragma: no cover - fallback if data files are unavailable
     rural_hh_by_region_year: dict[int, dict[str, float]] = {}
 else:
     if not regions:
-        raise ValueError("spatial_config defines no regions")
+        raise ValueError("demand defines no regions")
 
 from data_input import get_parameters
 
@@ -62,7 +62,7 @@ def project_household_energy_demand(urban_hh: float, rural_hh: float) -> float:
     """Return total annual cooking energy demand given household counts.
 
     Multiplies the number of urban and rural households by their respective
-    per‑household demand constants defined in :mod:`spatial_config`.
+    per‑household demand constants defined in :mod:`demand`.
     """
 
     if not isinstance(urban_hh, Real) or urban_hh < 0:

--- a/modelling_cost.py
+++ b/modelling_cost.py
@@ -32,7 +32,7 @@ from functools import lru_cache
 from typing import Dict, List, Tuple
 import pandas as pd
 
-from spatial_config import (
+from demand import (
     regions,
     demand_by_region_year,
     urban_hh_by_region_year,

--- a/spatial_config.py
+++ b/spatial_config.py
@@ -1,87 +1,28 @@
+"""Spatial configuration utilities.
+
+This module now delegates demographic and demand calculations to the
+``demand`` package but retains the helper for generating the
+``results/buses.csv`` table used by PyPSA export utilities.
+"""
+
+from __future__ import annotations
+
 import os
-from functools import lru_cache
 import pandas as pd
 
-from paths import get_data_path
-
-# NOTE: Technology adoption is handled in the modelling modules; this
-# configuration module does not import from the deprecated `scripts`
-# package.
-
-
-
-@lru_cache()
-def load_demographics() -> pd.DataFrame:
-    """Load district-level household projections."""
-
-    path = os.path.join("data", "District-level_Household_Projections.csv")
-    try:
-        df = pd.read_csv(path)
-    except FileNotFoundError as exc:
-        raise FileNotFoundError(
-            f"Demographic projection file not found: {path}"
-        ) from exc
-    df.columns = df.columns.str.strip()
-    df.set_index(["District", "Year"], inplace=True)
-    return df
-
-# Load once for module-level calculations but keep loader for reuse
-demographics = load_demographics()
-
-# Load demographic data (district-level household projections)
-demographics = pd.read_csv(
-    get_data_path("District-level_Household_Projections.csv")
+from demand import (
+    regions,
+    URBAN_DEMAND_GJ_PER_HH,
+    RURAL_DEMAND_GJ_PER_HH,
+    demand_by_region_year,
+    urban_hh_by_region_year,
+    rural_hh_by_region_year,
 )
-demographics.columns = demographics.columns.str.strip()
-demographics.set_index(['District', 'Year'], inplace=True)
 
 
-# Extract regions (districts)
-regions = sorted(demographics.index.get_level_values("District").unique())
-
-# Assumed cooking energy demand per household in GJ/year (source: IEA country brief for Côte d'Ivoire, 2024)
-URBAN_DEMAND_GJ_PER_HH = 6.5  # IEA (2024), page 5
-RURAL_DEMAND_GJ_PER_HH = 5.5  # IEA (2024), page 5
-
-
-def compute_demand_by_region_year(df: pd.DataFrame | None = None):
-    df = df if df is not None else demographics
-    required_cols = {"Urban_Households", "Rural_Households"}
-    missing = required_cols - set(df.columns)
-    if missing:
-        raise KeyError(
-            f"Missing required columns: {', '.join(sorted(missing))}"
-        )
-
-    demand = {}
-    for (district, year), row in df.iterrows():
-        if year not in demand:
-            demand[year] = {}
-        urban_demand = row["Urban_Households"] * URBAN_DEMAND_GJ_PER_HH
-        rural_demand = row["Rural_Households"] * RURAL_DEMAND_GJ_PER_HH
-        total_demand = urban_demand + rural_demand
-        demand[year][district] = total_demand
-    return demand
-
-
-def compute_urban_rural_hh_by_region_year(df: pd.DataFrame | None = None):
-    df = df if df is not None else demographics
-    urban = {}
-    rural = {}
-    for (district, year), row in df.iterrows():
-        if year not in urban:
-            urban[year] = {}
-            rural[year] = {}
-        urban[year][district] = row["Urban_Households"]
-        rural[year][district] = row["Rural_Households"]
-    return urban, rural
-
-# Precompute values for use in optimization and adoption models
-demand_by_region_year = compute_demand_by_region_year()
-urban_hh_by_region_year, rural_hh_by_region_year = compute_urban_rural_hh_by_region_year()
-
-
-def generate_buses_csv(output_path: str = os.path.join("results", "buses.csv")) -> pd.DataFrame:
+def generate_buses_csv(
+    output_path: str = os.path.join("results", "buses.csv")
+) -> pd.DataFrame:
     """Create a buses table with node metadata.
 
     The table contains one row per region and year with the number of
@@ -118,6 +59,17 @@ def generate_buses_csv(output_path: str = os.path.join("results", "buses.csv")) 
     return buses_df
 
 
+__all__ = [
+    "regions",
+    "URBAN_DEMAND_GJ_PER_HH",
+    "RURAL_DEMAND_GJ_PER_HH",
+    "demand_by_region_year",
+    "urban_hh_by_region_year",
+    "rural_hh_by_region_year",
+    "generate_buses_csv",
+]
+
+
 if __name__ == "__main__":
-    buses_df = generate_buses_csv()
+    generate_buses_csv()
 

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def demographics_module(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "District": ["A"],
+            "Year": [2020],
+            "Urban_Households": [1],
+            "Rural_Households": [2],
+        }
+    )
+    monkeypatch.setattr(pd, "read_csv", lambda *args, **kwargs: df.copy())
+    if "demand.demographics" in sys.modules:
+        del sys.modules["demand.demographics"]
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+    module = importlib.import_module("demand.demographics")
+    return module
+
+
+@pytest.mark.parametrize("missing_col", ["Urban_Households", "Rural_Households"])
+def test_compute_demand_by_region_year_missing_columns(demographics_module, monkeypatch, missing_col):
+    df = pd.DataFrame(
+        {
+            "District": ["A"],
+            "Year": [2020],
+            "Urban_Households": [1],
+            "Rural_Households": [2],
+        }
+    ).drop(columns=[missing_col])
+    df.set_index(["District", "Year"], inplace=True)
+    monkeypatch.setattr(demographics_module, "demographics", df)
+    with pytest.raises(KeyError, match=missing_col):
+        demographics_module.compute_demand_by_region_year()
+

--- a/tests/test_energy_demand.py
+++ b/tests/test_energy_demand.py
@@ -5,6 +5,8 @@ import types
 
 import pandas as pd
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 
 def _prepare_modules(monkeypatch):
     """Patch data loading and import target modules."""
@@ -26,24 +28,25 @@ def _prepare_modules(monkeypatch):
     era5_stub.load_era5_series = lambda *args, **kwargs: None
     monkeypatch.setitem(sys.modules, "era5_profiles", era5_stub)
 
-    monkeypatch.delitem(sys.modules, "spatial_config", raising=False)
+    monkeypatch.delitem(sys.modules, "demand", raising=False)
+    monkeypatch.delitem(sys.modules, "demand.demographics", raising=False)
     monkeypatch.delitem(sys.modules, "energy_demand_model", raising=False)
 
-    spatial_config = importlib.import_module("spatial_config")
+    demand_module = importlib.import_module("demand")
     energy_demand_model = importlib.import_module("energy_demand_model")
-    return spatial_config, energy_demand_model
+    return demand_module, energy_demand_model
 
 
 def test_cooking_demand_increases(monkeypatch):
-    spatial_config, energy_demand_model = _prepare_modules(monkeypatch)
+    demand_module, energy_demand_model = _prepare_modules(monkeypatch)
 
     base_year = 2030
     later_years = [2040, 2050]
 
     demands = energy_demand_model.total_cooking_demand_GJ_by_year_and_region
-    demand_by_year = spatial_config.demand_by_region_year
+    demand_by_year = demand_module.demand_by_region_year
 
-    for region in spatial_config.regions:
+    for region in demand_module.regions:
         base_total = demands[base_year][region]
         base_regional = demand_by_year[base_year][region]
         for year in later_years:

--- a/tests/test_energy_demand_model.py
+++ b/tests/test_energy_demand_model.py
@@ -10,13 +10,13 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 
 def _import_edm(monkeypatch, series):
-    spatial = types.ModuleType("spatial_config")
-    spatial.regions = ["dummy"]
-    spatial.URBAN_DEMAND_GJ_PER_HH = 0
-    spatial.RURAL_DEMAND_GJ_PER_HH = 0
-    spatial.urban_hh_by_region_year = {}
-    spatial.rural_hh_by_region_year = {}
-    monkeypatch.setitem(sys.modules, "spatial_config", spatial)
+    demand = types.ModuleType("demand")
+    demand.regions = ["dummy"]
+    demand.URBAN_DEMAND_GJ_PER_HH = 0
+    demand.RURAL_DEMAND_GJ_PER_HH = 0
+    demand.urban_hh_by_region_year = {}
+    demand.rural_hh_by_region_year = {}
+    monkeypatch.setitem(sys.modules, "demand", demand)
 
     era5 = types.ModuleType("era5_profiles")
     era5.load_era5_series = lambda *a, **k: series
@@ -45,16 +45,16 @@ def test_disaggregate_to_hourly_nonzero_profile(monkeypatch):
 
 
 def test_empty_regions_raises_value_error(monkeypatch):
-    spatial = types.ModuleType("spatial_config")
-    spatial.regions = []
-    spatial.URBAN_DEMAND_GJ_PER_HH = 0
-    spatial.RURAL_DEMAND_GJ_PER_HH = 0
-    spatial.urban_hh_by_region_year = {}
-    spatial.rural_hh_by_region_year = {}
+    demand = types.ModuleType("demand")
+    demand.regions = []
+    demand.URBAN_DEMAND_GJ_PER_HH = 0
+    demand.RURAL_DEMAND_GJ_PER_HH = 0
+    demand.urban_hh_by_region_year = {}
+    demand.rural_hh_by_region_year = {}
 
     sys.modules.pop("energy_demand_model", None)
-    sys.modules.pop("spatial_config", None)
-    monkeypatch.setitem(sys.modules, "spatial_config", spatial)
+    sys.modules.pop("demand", None)
+    monkeypatch.setitem(sys.modules, "demand", demand)
 
     with pytest.raises(ValueError):
         importlib.import_module("energy_demand_model")

--- a/tests/test_spatial_config.py
+++ b/tests/test_spatial_config.py
@@ -4,43 +4,6 @@ import sys
 from pathlib import Path
 
 import pandas as pd
-import pytest
-import importlib
-
-
-@pytest.fixture
-def spatial_config_module(monkeypatch):
-    df = pd.DataFrame(
-        {
-            "District": ["A"],
-            "Year": [2020],
-            "Urban_Households": [1],
-            "Rural_Households": [2],
-        }
-    )
-    monkeypatch.setattr(pd, "read_csv", lambda *args, **kwargs: df.copy())
-    if "spatial_config" in sys.modules:
-        del sys.modules["spatial_config"]
-    repo_root = Path(__file__).resolve().parents[1]
-    sys.path.insert(0, str(repo_root))
-    module = importlib.import_module("spatial_config")
-    return module
-
-
-@pytest.mark.parametrize("missing_col", ["Urban_Households", "Rural_Households"])
-def test_compute_demand_by_region_year_missing_columns(spatial_config_module, monkeypatch, missing_col):
-    df = pd.DataFrame(
-        {
-            "District": ["A"],
-            "Year": [2020],
-            "Urban_Households": [1],
-            "Rural_Households": [2],
-        }
-    ).drop(columns=[missing_col])
-    df.set_index(["District", "Year"], inplace=True)
-    monkeypatch.setattr(spatial_config_module, "demographics", df)
-    with pytest.raises(KeyError, match=missing_col):
-        spatial_config_module.compute_demand_by_region_year()
 
 
 def test_generate_buses_csv_only_when_run_as_script(tmp_path):
@@ -78,3 +41,4 @@ def test_generate_buses_csv_only_when_run_as_script(tmp_path):
         check=True,
     )
     assert results_file.exists()
+


### PR DESCRIPTION
## Summary
- Introduced `demand` subpackage with demographics loader and region/year demand calculations
- Exposed `demand.get_demand(year)` API and rewired models and analysis scripts to use it
- Added a data-flow diagram to the README documenting inputs, intermediate outputs, and consumers

## Testing
- `pytest -q`

