### PR TITLE
feat: externalise configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ with underscores.
   ``glpsol`` binary and ``--solver gurobi`` needs a licensed Gurobi
   installation.
 
+## Configuration
+
+Default scenarios, model years, policy constraints and solver
+preferences are defined in `config/scenarios.yaml`. An equivalent JSON
+file (`config/scenarios.json`) is also provided. The YAML structure is
+straightforward::
+
+```yaml
+scenarios: [bau, clean_push, biogas_incentive]
+years: [2030, 2040, 2050]
+constraints:
+  min_clean_share: 0.4
+  max_firewood_share: 0.3
+solver: cbc
+```
+
+To use a custom configuration, pass ``--config path/to/file.yaml`` to
+``main.py``. Individual options can be overridden on the command line,
+e.g. ``--min-clean-share 0.5``.
+
 ## Preparing ERA5 weather cutouts
 
 Some analyses rely on hourly weather variables from the ERA5 reanalysis.
@@ -102,7 +122,8 @@ outside the repository (e.g. in a release asset or shared drive).
    technology and a `Summary` sheet with total costs by scenario and
    year. When optimisation is enabled, policy constraints for the
    minimum clean share and maximum firewood share are taken from
-   `config.py`.
+   the configuration file (`config/scenarios.yaml`) and can be
+   overridden with ``--min-clean-share`` or ``--max-firewood-share``.
 
    Append ``--pypsa-export`` to additionally produce CSV files
    compatible with `PyPSA‑Earth <https://pypsa-earth.readthedocs.io/>`_:

--- a/config.py
+++ b/config.py
@@ -1,23 +1,52 @@
-"""Global modelling configuration for CI bioenergy scenarios.
+"""Configuration utilities for CI bioenergy scenarios.
 
-This module centralises scenario and evaluation year settings so
-that all modelling pipelines use a consistent configuration.
-
-Shared configuration for modelling scenarios and years.
+Configuration defaults are stored in ``config/scenarios.yaml``.
+``load_config`` returns the parsed dictionary and can handle YAML or JSON
+files.
 """
 from __future__ import annotations
 
-from typing import List
+import json
+import os
+from typing import Any, Dict
 
-# Scenarios to evaluate
-SCENARIOS: List[str] = ["bau", "clean_push", "biogas_incentive"]
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
 
-# Model years
-YEARS: List[int] = [2030, 2040, 2050]
+# Default configuration shipped with the repository
+DEFAULT_CONFIG_PATH = os.path.join(
+    os.path.dirname(__file__), "config", "scenarios.yaml"
+)
 
-# Policy constraints for optimisation
-# Minimum share of clean technologies (fraction of total demand)
-MIN_CLEAN_SHARE: float = 0.4
-# Maximum share of traditional firewood (fraction of total demand)
-MAX_FIREWOOD_SHARE: float = 0.3
 
+def load_config(path: str | None = None) -> Dict[str, Any]:
+    """Load scenario configuration from a YAML or JSON file.
+
+    Parameters
+    ----------
+    path : str, optional
+        Path to the configuration file. If omitted, ``DEFAULT_CONFIG_PATH``
+        is used.
+
+    Returns
+    -------
+    dict
+        Parsed configuration dictionary.
+    """
+    cfg_path = path or DEFAULT_CONFIG_PATH
+    with open(cfg_path, "r", encoding="utf-8") as fh:
+        if cfg_path.endswith(('.yaml', '.yml')):
+            if yaml is None:
+                raise RuntimeError(
+                    "PyYAML is required to read YAML configuration files."
+                )
+            return yaml.safe_load(fh)
+        if cfg_path.endswith('.json'):
+            return json.load(fh)
+        raise ValueError(f"Unsupported config format: {cfg_path}")
+
+
+# Eagerly load default configuration for convenience
+CONFIG = load_config()

--- a/config/scenarios.json
+++ b/config/scenarios.json
@@ -1,0 +1,9 @@
+{
+  "scenarios": ["bau", "clean_push", "biogas_incentive"],
+  "years": [2030, 2040, 2050],
+  "constraints": {
+    "min_clean_share": 0.4,
+    "max_firewood_share": 0.3
+  },
+  "solver": "cbc"
+}

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -1,0 +1,12 @@
+scenarios:
+  - bau
+  - clean_push
+  - biogas_incentive
+years:
+  - 2030
+  - 2040
+  - 2050
+constraints:
+  min_clean_share: 0.4
+  max_firewood_share: 0.3
+solver: cbc

--- a/modelling_cost.py
+++ b/modelling_cost.py
@@ -43,12 +43,7 @@ from spatial_config import (
 from technology_adoption_model import get_tech_mix_by_scenario
 from model import run_cost_fixed_mix, run_cost_minimise_cost, pulp
 from energy_demand_model import disaggregate_to_hourly
-from config import (
-    SCENARIOS,
-    YEARS,
-    MIN_CLEAN_SHARE,
-    MAX_FIREWOOD_SHARE,
-)
+from config import CONFIG, load_config
 from paths import get_data_path
 
 DISCOUNT_RATE = 0.05
@@ -181,7 +176,10 @@ def run_all_scenarios(
     years: List[int] | None = None,
     optimise: bool = False,
     timeseries: str = "none",
-    solver: str = "cbc",
+    solver: str | None = None,
+    config: Dict | str | None = None,
+    min_clean_share: float | None = None,
+    max_firewood_share: float | None = None,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
 
     """Execute the cost optimisation pipeline across all scenarios and years.
@@ -192,15 +190,26 @@ def run_all_scenarios(
     Parameters
     ----------
     scenarios : list, optional
-        Scenario names to evaluate. Defaults to :data:`config.SCENARIOS`.
+        Scenario names to evaluate. Defaults to the values defined in the
+        configuration file.
     years : list, optional
-        Model years to process. Defaults to :data:`config.YEARS`.
+        Model years to process. Defaults to the configuration file.
     optimise : bool, optional
         If ``True``, solve a least-cost optimisation using PuLP.
         Otherwise use the fixed adoption shares.
     solver : str, optional
         Optimisation solver to use when ``optimise`` is ``True``.
-        Choices are ``"cbc"``, ``"glpk"`` and ``"gurobi"``.
+        Choices are ``"cbc"``, ``"glpk"`` and ``"gurobi"``. Defaults to the
+        ``solver`` entry in the configuration.
+    config : dict or str, optional
+        Configuration dictionary or path to a YAML/JSON file. When omitted the
+        built-in default configuration is used.
+    min_clean_share : float, optional
+        Override for the minimum clean-technology share constraint. Falls back
+        to ``constraints.min_clean_share`` from the configuration.
+    max_firewood_share : float, optional
+        Override for the maximum traditional firewood share constraint. Falls
+        back to ``constraints.max_firewood_share`` from the configuration.
 
     Returns
     -------
@@ -208,8 +217,25 @@ def run_all_scenarios(
         A tuple containing the detailed results for each region and the
         summary of total costs by scenario and year.
     """
-    scenarios = scenarios or SCENARIOS
-    years = years or YEARS
+    cfg = (
+        load_config(config) if isinstance(config, str)
+        else config if isinstance(config, dict)
+        else CONFIG
+    )
+    scenarios = scenarios or cfg.get("scenarios", [])
+    years = years or cfg.get("years", [])
+    constraints = cfg.get("constraints", {})
+    min_clean_share = (
+        min_clean_share
+        if min_clean_share is not None
+        else constraints.get("min_clean_share", 0.0)
+    )
+    max_firewood_share = (
+        max_firewood_share
+        if max_firewood_share is not None
+        else constraints.get("max_firewood_share", 1.0)
+    )
+    solver = solver or cfg.get("solver", "cbc")
     os.makedirs("results", exist_ok=True)
 
     if optimise and pulp is None:
@@ -257,8 +283,8 @@ def run_all_scenarios(
                         year,
                         reg,
                         demand,
-                        MIN_CLEAN_SHARE,
-                        MAX_FIREWOOD_SHARE,
+                        min_clean_share,
+                        max_firewood_share,
                         tech_costs,
                         solver=solver,
                     )

--- a/modelling_stock_flow.py
+++ b/modelling_stock_flow.py
@@ -12,7 +12,7 @@ household consumption intensities, allocating that demand across
 different technologies under scenario assumptions and computing the
 resulting emissions.
 
-Scenarios are defined in ``SCENARIOS`` and currently include:
+Scenarios are defined in the configuration file and currently include:
 
 * ``bau`` – business as usual adoption trajectories
 * ``clean_push`` – concerted push for clean alternatives
@@ -44,7 +44,7 @@ from technology_adoption_model import (
     generate_adoption_tables,
 )
 from ghg_emissions_model import calculate_emissions
-from config import SCENARIOS, YEARS
+from config import CONFIG, load_config
 
 
 def _map_energy_categories(energy_by_tech: Dict[str, float]) -> Dict[str, float]:
@@ -96,16 +96,21 @@ def run_all_scenarios(
     scenarios: List[str] | None = None,
     years: List[int] | None = None,
     timeseries: str = "none",
+    config: Dict | str | None = None,
 ) -> Dict[str, pd.DataFrame]:
     """Execute all stock‑flow scenarios and write results to Excel and CSV.
 
     Parameters
     ----------
     scenarios : list, optional
-        Scenario names to evaluate. Defaults to :data:`config.SCENARIOS`.
+        Scenario names to evaluate. Defaults to the values from the
+        configuration file.
     years : list, optional
-        Model years to process. Defaults to :data:`config.YEARS`.
-
+        Model years to process. Defaults to the configuration file.
+    config : dict or str, optional
+        Configuration dictionary or path to a YAML/JSON file. If omitted
+        the built-in defaults are used.
+    
     Returns
     -------
     dict
@@ -114,8 +119,13 @@ def run_all_scenarios(
         energy demand, energy allocation by technology and detailed
         emission estimates.
     """
-    scenarios = scenarios or SCENARIOS
-    years = years or YEARS
+    cfg = (
+        load_config(config) if isinstance(config, str)
+        else config if isinstance(config, dict)
+        else CONFIG
+    )
+    scenarios = scenarios or cfg.get("scenarios", [])
+    years = years or cfg.get("years", [])
     params = get_parameters()
     os.makedirs("results", exist_ok=True)
     results_per_scenario: Dict[str, pd.DataFrame] = {}


### PR DESCRIPTION
## Summary
- move scenario configuration to `config/scenarios.yaml`
- allow `run_all_scenarios` functions to load config dicts or files
- add CLI options for config path and policy overrides
- document configuration and overrides in README

## Testing
- `pytest`

